### PR TITLE
Update Trino catalog volume path in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     ports: 
       - "8080:8080"
     volumes:
-      - ./etc/catalog:/etc/trino/catalog
+      - ./dev_env/etc/catalog:/etc/trino/catalog
     networks:
       - dev_lab
 


### PR DESCRIPTION
## Description
updated docker-compose.yml volume for trino with dev_env folder updated to contain the etc/catalog/*properties files the trino service uses