### PR TITLE
Add search_fraud_checks endpoint to FlashpointConnector

### DIFF
--- a/dev_env/api/test_flashpoint.py
+++ b/dev_env/api/test_flashpoint.py
@@ -1,32 +1,16 @@
-from pyapiary.api_connectors.flashpoint import FlashpointConnector
+import asyncio
 import httpx
+from pyapiary.api_connectors.flashpoint import FlashpointConnector, AsyncFlashpointConnector
 
-fp = FlashpointConnector(
+fp = AsyncFlashpointConnector(
     load_env_vars=True,
     trust_env=True,
     verify=False,
     follow_redirects=True
 )
 
-# res = fp.search_communities('telegram')
-# print(res)
+async def main():
+    # Insert test here
+    pass
 
-
-try:
-    resp = fp.get_media_image(
-        "gs://kraken-datalake-media/artifacts/67/6739eed871575b5ad1864ea66d42ebf2430eda5f34d40715c9e40efe90232aa6",
-        headers={},
-        request_kwargs={"follow_redirects": True},
-    )
-    print("Final URL:", resp.url)
-    print("Final status:", resp.status_code)
-except httpx.HTTPStatusError as e:
-    resp = e.response
-    print("Final error:", resp.status_code, resp.url)
-
-    # Show the chain of redirects
-    for hop in resp.history:
-        print("Redirect:", hop.status_code, hop.url, "->", hop.headers.get("location"))
-
-    # Show body of final error if any
-    print("Response body:", resp.text[:500])
+asyncio.run(main())

--- a/dev_env/api/test_ipqs.py
+++ b/dev_env/api/test_ipqs.py
@@ -17,7 +17,7 @@ async def main():
     )
 
     res = await ipqs.malicious_url(
-        query="cracked.to"
+        query="bad.url"
     )
 
     print(res)

--- a/dev_env/api/test_urlscan.py
+++ b/dev_env/api/test_urlscan.py
@@ -18,7 +18,7 @@ sample_scan_uuid = "0198d378-c19e-707c-add7-45c289b2851c"
 
 
 # ---------- sync ----------
-res = urlscan.search("bclubs.cc")
+res = urlscan.search("google.com")
 print(res.status_code)
 
 res = urlscan.scan("google.com")

--- a/src/pyapiary/api_connectors/flashpoint.py
+++ b/src/pyapiary/api_connectors/flashpoint.py
@@ -45,6 +45,16 @@ class FlashpointConnector(Broker):
         return self.post("/sources/v2/fraud", json={"query": query, **kwargs})
 
     @log_method_call
+    def search_fraud_checks(self, query: str, **kwargs) -> httpx.Response:
+        """Checks search provides the ability to search and read data from our Checks dataset.
+
+        Args:
+            query (str): The search string used in the API query.
+            **kwargs: Additional query logic per the Flashpoint API documentation.
+        """
+        return self.post("/sources/v2/fraud/checks", json={"query": query, **kwargs})
+
+    @log_method_call
     def search_marketplaces(self, query: str, **kwargs) -> httpx.Response:
         """
         Search Flashpoint marketplace datasets.
@@ -139,6 +149,16 @@ class AsyncFlashpointConnector(AsyncBroker):
             **kwargs: Additional query logic per the Flashpoint API documentation.
         """
         return await self.post("/sources/v2/fraud", json={"query": query, **kwargs})
+
+    @log_method_call
+    async def search_fraud_checks(self, query: str, **kwargs) -> httpx.Response:
+        """Checks search provides the ability to search and read data from our Checks dataset.
+
+        Args:
+            query (str): The search string used in the API query.
+            **kwargs: Additional query logic per the Flashpoint API documentation.
+        """
+        return await self.post("/sources/v2/fraud/checks", json={"query": query, **kwargs})
 
     @log_method_call
     async def search_marketplaces(self, query: str, **kwargs) -> httpx.Response:

--- a/src/pyapiary/tests/test_flashpoint/test_unit_async_flashpoint.py
+++ b/src/pyapiary/tests/test_flashpoint/test_unit_async_flashpoint.py
@@ -28,6 +28,57 @@ async def test_async_init_missing_key():
 
 @patch("pyapiary.api_connectors.flashpoint.AsyncFlashpointConnector.post", new_callable=AsyncMock)
 @pytest.mark.asyncio
+async def test_async_search_fraud_checks(mock_post):
+    import json
+
+    request = httpx.Request("POST", "https://api.flashpoint.io/mock")
+    payload = {"success": True, "data": []}
+    mock_response = httpx.Response(
+        200,
+        request=request,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    mock_post.return_value = mock_response
+
+    connector = AsyncFlashpointConnector(api_key="mock_token")
+    result = await connector.search_fraud_checks("stolen checks")
+
+    assert isinstance(result, httpx.Response)
+    assert result.json() == payload
+    mock_post.assert_awaited_once_with(
+        "/sources/v2/fraud/checks", json={"query": "stolen checks"}
+    )
+
+
+@patch("pyapiary.api_connectors.flashpoint.AsyncFlashpointConnector.post", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_async_search_fraud_checks_with_kwargs(mock_post):
+    import json
+
+    request = httpx.Request("POST", "https://api.flashpoint.io/mock")
+    payload = {"success": True, "data": [{"id": "abc123"}]}
+    mock_response = httpx.Response(
+        200,
+        request=request,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    mock_post.return_value = mock_response
+
+    connector = AsyncFlashpointConnector(api_key="mock_token")
+    result = await connector.search_fraud_checks("routing number", size=10, from_=0)
+
+    assert isinstance(result, httpx.Response)
+    assert result.json() == payload
+    mock_post.assert_awaited_once_with(
+        "/sources/v2/fraud/checks",
+        json={"query": "routing number", "size": 10, "from_": 0},
+    )
+
+
+@patch("pyapiary.api_connectors.flashpoint.AsyncFlashpointConnector.post", new_callable=AsyncMock)
+@pytest.mark.asyncio
 async def test_async_search_fraud(mock_post):
     import json
 

--- a/src/pyapiary/tests/test_flashpoint/test_unit_flashpoint.py
+++ b/src/pyapiary/tests/test_flashpoint/test_unit_flashpoint.py
@@ -23,6 +23,55 @@ def test_init_missing_key():
 
 
 @patch("pyapiary.api_connectors.flashpoint.FlashpointConnector.post")
+def test_search_fraud_checks(mock_post):
+    import json
+
+    request = httpx.Request("POST", "https://api.flashpoint.io/mock")
+    payload = {"success": True, "data": []}
+    mock_response = httpx.Response(
+        200,
+        request=request,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    mock_post.return_value = mock_response
+
+    connector = FlashpointConnector(api_key="mock_token")
+    result = connector.search_fraud_checks("stolen checks")
+
+    assert isinstance(result, httpx.Response)
+    assert result.json() == payload
+    mock_post.assert_called_once_with(
+        "/sources/v2/fraud/checks", json={"query": "stolen checks"}
+    )
+
+
+@patch("pyapiary.api_connectors.flashpoint.FlashpointConnector.post")
+def test_search_fraud_checks_with_kwargs(mock_post):
+    import json
+
+    request = httpx.Request("POST", "https://api.flashpoint.io/mock")
+    payload = {"success": True, "data": [{"id": "abc123"}]}
+    mock_response = httpx.Response(
+        200,
+        request=request,
+        content=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    mock_post.return_value = mock_response
+
+    connector = FlashpointConnector(api_key="mock_token")
+    result = connector.search_fraud_checks("routing number", size=10, from_=0)
+
+    assert isinstance(result, httpx.Response)
+    assert result.json() == payload
+    mock_post.assert_called_once_with(
+        "/sources/v2/fraud/checks",
+        json={"query": "routing number", "size": 10, "from_": 0},
+    )
+
+
+@patch("pyapiary.api_connectors.flashpoint.FlashpointConnector.post")
 def test_search_fraud(mock_post):
     import json
 


### PR DESCRIPTION
## Summary
- Adds `search_fraud_checks` method to both `FlashpointConnector` (sync) and `AsyncFlashpointConnector` (async), posting to `/sources/v2/fraud/checks`
- Adds unit tests for both sync and async variants, covering basic query and kwargs passthrough

## Test plan
- [x] `pytest src/pyapiary/tests/test_flashpoint/test_unit_flashpoint.py` — all tests pass
- [x] `pytest src/pyapiary/tests/test_flashpoint/test_unit_async_flashpoint.py` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)